### PR TITLE
[SKP-169-sights-to-travel] 명소 -> 여행지 워딩 변경

### DIFF
--- a/src/hooks/mutations/category/useDeleteCategory.ts
+++ b/src/hooks/mutations/category/useDeleteCategory.ts
@@ -6,7 +6,7 @@ interface DeleteCategoryRequest {
 }
 
 /**
- *  명소 삭제
+ *  카테고리 삭제
  */
 export const deleteCategory = async ({
   userCategoryId,

--- a/src/hooks/mutations/location/useDeleteLocation.ts
+++ b/src/hooks/mutations/location/useDeleteLocation.ts
@@ -6,7 +6,7 @@ interface DeleteLocationRequest {
 }
 
 /**
- *  명소 삭제
+ *  여행지 삭제
  */
 export const deleteLocation = async ({
   userLocationId,

--- a/src/hooks/mutations/location/usePatchLocation.ts
+++ b/src/hooks/mutations/location/usePatchLocation.ts
@@ -9,7 +9,7 @@ interface ModifyLocationRequest {
 }
 
 /**
- *  명소 정보 수정 (카테고리)
+ *  여행지 정보 수정 (카테고리)
  */
 export const modifyLocation = async ({
   userLocationId,

--- a/src/hooks/mutations/location/usePatchLocationReAnalyze.ts
+++ b/src/hooks/mutations/location/usePatchLocationReAnalyze.ts
@@ -7,7 +7,7 @@ export interface ReanalyzeRequest {
 }
 
 /**
- *  명소 재분석
+ *  여행지 재분석
  */
 export const reanlyzeLocation = async ({
   userLocationList,

--- a/src/hooks/mutations/location/usePostLocation.ts
+++ b/src/hooks/mutations/location/usePostLocation.ts
@@ -12,7 +12,7 @@ export interface AnalyzeLocationResponse {
 }
 
 /**
- *  명소 추가 (스크린샷 분석, 카테고리 분류)
+ *  여행지 추가 (스크린샷 분석, 카테고리 분류)
  */
 export const addLocation = async (formdata: FormData) => {
   const res = await POST<AnalyzeLocationResponse>(

--- a/src/hooks/mutations/location/usePostTourLocation.ts
+++ b/src/hooks/mutations/location/usePostTourLocation.ts
@@ -8,7 +8,7 @@ interface AddTourLocationReqeust {
   category: ICategory;
 }
 /**
- *  관광 명소 추가
+ *  관광명소 여행지로 추가
  */
 export const addTourLocation = async ({
   tourLocation,

--- a/src/hooks/queries/location/useGetLocation.ts
+++ b/src/hooks/queries/location/useGetLocation.ts
@@ -4,7 +4,7 @@ import {LOCATION_KEYS} from '../QueryKeys';
 import {UserLocation} from '../../../types/dtos/location';
 
 /**
- *  명소 상세 조회
+ *  여행지 상세 조회
  */
 export const getLocation = async (userLocationId: number) => {
   const {data} = await GET<UserLocation>(

--- a/src/screens/AnalyzeResult/AnalyzeResult.tsx
+++ b/src/screens/AnalyzeResult/AnalyzeResult.tsx
@@ -33,9 +33,9 @@ export default function AnalyzeResult({navigation, route}: AnalyzeResultProps) {
       analyzeState === AnalyzeState.SUCCESS &&
       type === AnalyzeCount.MULTIPLE
     )
-      return `${result.successCount}개의 명소를 캐치했어요!`;
+      return `${result.successCount}개의 여행지를 캐치했어요!`;
     else if (analyzeState === AnalyzeState.PARTIAL)
-      return `${result.successCount}개의 명소를 캐치했어요!`;
+      return `${result.successCount}개의 여행지를 캐치했어요!`;
   }, [analyzeState]);
 
   const subtitle = useMemo(() => {

--- a/src/screens/DetailTour/DetailTour.tsx
+++ b/src/screens/DetailTour/DetailTour.tsx
@@ -61,7 +61,7 @@ export default function DetailTour({navigation, route}: DetailTourProps) {
       setIsLoading(false);
       DeviceEventEmitter.emit('openToast', {
         content: (
-          <Text style={styles.snackbarText}>명소 저장에 실패했습니다</Text>
+          <Text style={styles.snackbarText}>여행지 저장에 실패했습니다</Text>
         ),
       });
     },

--- a/src/screens/Login/Login.tsx
+++ b/src/screens/Login/Login.tsx
@@ -10,7 +10,7 @@ export default function Login() {
         앨범 속 수많은 스크린샷, {'\n'}
         이제 스킵에서 빠르게 저장해요
       </Text>
-      <Text style={styles.subtitle}>벌써 1123개의 명소가 저장되었어요.</Text>
+      <Text style={styles.subtitle}>벌써 1123개의 여행지가 저장되었어요.</Text>
       <Image
         source={require('../../assets/icon/ic_login.gif')}
         style={styles.gifContainer}

--- a/src/screens/Withdraw/Withdraw.tsx
+++ b/src/screens/Withdraw/Withdraw.tsx
@@ -115,7 +115,7 @@ export default function Withdraw({navigation}: WithdrawProps) {
           탈퇴 즉시, {userInfo.username}님의 모든 이용 내역은 삭제돼요.
         </Text>
         <Text style={styles.infoText}>
-          계정 정보, 등록된 명소, 친구 등 스킵에서 활동했던 모든 내용들은
+          계정 정보, 등록된 여행지, 친구 등 스킵에서 활동했던 모든 내용들은
           삭제되며, 다시 가입해도 복구되지 않아요!
         </Text>
       </View>


### PR DESCRIPTION
## 🏆 Details
- [x] 로그인, 탈퇴, 분석 결과, 상세에서 명소 -> 여행지 워딩 변경
- [x] 리프레시 로직 수

## ✅ Need Review
- 리프레시 로직을 조금 수정하였습니다
    - 리프레시 실패 시에도 로그인 화면으로 이동
    - 리프레시 실패 시에도 실패 큐 비우기 (3번 호출되는 문제)
    - 실패 시, 삭제하고 로그인 화면으로 이동하는 부분 함수화
